### PR TITLE
ADD: Call to action section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import LogoTicker from "@/components/LogoTicker";
 import ProductShowcase from "@/components/ProductShowcase";
 import Pricing from "@/components/Pricing";
 import { Testimonials } from "@/components/Testimonials";
+import CallToAction from "@/components/CallToAction";
 
 export default function Home() {
   return (
@@ -14,6 +15,7 @@ export default function Home() {
       <ProductShowcase />
       <Pricing />
       <Testimonials/>
+      <CallToAction/>
     </>
   );
 }

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import ArrowRight from "@/assets/arrow-right.svg";
+import StarImage from "@/assets/star.png";
+import SpringImage from "@/assets/spring.png";
+import Image from "next/image";
+
+const CallToAction = () => {
+  return (
+    <section className="bg-gradient-to-b from-white to-[#D2DCFF] py-24 overflow-x-clip">
+      <div className="container">
+        <div className="section-heading relative">
+          <h2 className="section-title">Sign up for free today</h2>
+          <p className="section-description mt-5">
+            Celebrate the joy of accomplishment with an app designed to track
+            your progress and motivate your efforts.
+          </p>
+          <Image
+            src={StarImage}
+            alt="Star image"
+            width={360}
+            className="absolute -left-[350px] -top-[137px]"
+          />
+          <Image
+            src={SpringImage}
+            alt="Spring image"
+            width={360}
+            className="absolute -right-[331px] -top-[19px]"
+          />
+        </div>
+        <div className="flex gap-2 mt-10 justify-center">
+          <button className="btn btn-primary">Get for free</button>
+          <button className="btn btn-text gap-1 group">
+            <span>Learn more</span>
+            <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-all" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CallToAction;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96684dde-c9e3-4db6-b8df-f18bd312b450)
This pull request introduces a new `CallToAction` component and integrates it into the home page. The changes include importing the new component, adding it to the home page layout, and defining the component with its associated assets and styles.

### Integration of `CallToAction` component:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR7): Imported the `CallToAction` component and added it to the home page layout. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR7) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR18)

### Definition of `CallToAction` component:

* [`src/components/CallToAction.tsx`](diffhunk://#diff-0c37d077d0efc929eea3cc30c7abb6c6ddad652c5208c8c6b1651c6f00793a18R1-R42): Created the `CallToAction` component, including imports for assets like `ArrowRight`, `StarImage`, and `SpringImage`. Defined the component structure with a section for sign-up and buttons for "Get for free" and "Learn more".